### PR TITLE
Added 'thin-provisioning-tools' to be installed for role "volume".

### DIFF
--- a/hooks/cinder_utils.py
+++ b/hooks/cinder_utils.py
@@ -134,7 +134,12 @@ COMMON_PACKAGES = [
 ]
 
 API_PACKAGES = ['cinder-api']
-VOLUME_PACKAGES = ['cinder-volume']
+
+VOLUME_PACKAGES = [
+    'cinder-volume',
+	'thin-provisioning-tools',
+]
+
 SCHEDULER_PACKAGES = ['cinder-scheduler']
 
 BASE_GIT_PACKAGES = [


### PR DESCRIPTION
As described in [https://bugs.launchpad.net/charm-cinder/+bug/1730403](https://bugs.launchpad.net/charm-cinder/+bug/1730403), the volume service gives trouble because lvm2 does not automatically install 'thin-provisioning-tools'. This PR adds 'thin-provisioning-tools' to the installed VOLUME_PACKAGES to solve that bug.