### PR TITLE
StorageBackendContext: only enable the default backend for ocata+

### DIFF
--- a/hooks/cinder_contexts.py
+++ b/hooks/cinder_contexts.py
@@ -137,9 +137,9 @@ class StorageBackendContext(OSContextGenerator):
                 backends.append('CEPH')
             if enable_lvm():
                 backends.append('LVM')
-        # Use the package default backend to stop the service flapping.
-        if not backends:
-            backends = ['LVM']
+            # Use the package default backend to stop the service flapping.
+            if not backends:
+                backends = ['LVM']
         return {
             'active_backends': backends,
             'backends': ",".join(backends)}


### PR DESCRIPTION
When deploying on icehouse with Ceph, the RBD backend is
configured globally, but the charm sets enabled_backends to
"LVM", which doesn't exist, and is wrong to boot (LP:1753611).

This commit moves the check for empty "backends" under the ocata
check.  Per comment #5 on LP:1719742: "The cinder-volume service
fails to start in ocata+ if enable-backends is not set."

Please also backport to stable, to 17.11 if possible, since that is the
release for which we are planning and testing.  This is also the release
against which I tested this patch.