### PR TITLE
Create volume-backend-name config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -92,6 +92,10 @@ options:
       If True, charm will attempt to remove missing physical volumes from
       volume group, even when logical volumes are allocated on them. This
       option overrides 'remove-missing' when set.
+  volume-backend-name:
+    type: string
+    default: LVM
+    description: Name of volume backend to associate with Cinder types.
   ephemeral-unmount:
     type: string
     default:

--- a/hooks/cinder_contexts.py
+++ b/hooks/cinder_contexts.py
@@ -143,7 +143,7 @@ class StorageBackendContext(OSContextGenerator):
             if relation_ids('ceph'):
                 backends.append('CEPH')
             if enable_lvm():
-                backends.append('LVM')
+                backends.append(config('volume-backend-name'))
             # Use the package default backend to stop the service flapping.
             if not backends:
                 backends = ['LVM']
@@ -242,7 +242,7 @@ class LVMContext(OSContextGenerator):
                 'volume_name_template': 'volume-%s',
                 'volume_group': config('volume-group'),
                 'volume_driver': 'cinder.volume.drivers.lvm.LVMVolumeDriver',
-                'volume_backend_name': 'LVM'}
+                'volume_backend_name': config('volume-backend-name')}
         return ctxt
 
 

--- a/templates/parts/backends
+++ b/templates/parts/backends
@@ -22,7 +22,7 @@ default_volume_type = {{ default_volume_type }}
 
 {% if sectional_default_config -%}
 {% if volume_driver -%}
-[LVM]
+[{{volume_backend_name}}]
 volumes_dir = {{ volumes_dir }}
 volume_name_template = {{ volume_name_template }}
 volume_group = {{ volume_group }}


### PR DESCRIPTION
The current LVM driver implementation defaults to naming all LVM
backends as "LVM." This method permits the distribution of volumes
across all LVM-based storage backends using a single Cinder type.
OpenStack implements granular control over volume placement via
the Cinder type association with specifically-named backends.
By setting the volume-backend-name attribute, and tying that name
with a Cinder type via the `volume_backend_name` attribute, an
operator can specifically zone volume placement for IOPs/capacity
or failure domains.